### PR TITLE
[feat] Phase 1 of IOCTL overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,9 @@ stamp-h1
 .libs/
 *.la
 *.lo
+
+# Compatibility with per-file VCS
+.history
+
+# Compatibility with locally generated documentation
+_doc

--- a/crates/zeroos-foundation/src/ioctl.rs
+++ b/crates/zeroos-foundation/src/ioctl.rs
@@ -1,0 +1,168 @@
+//! ioctl command encoding and decoding helpers.
+//!
+//! Follows the standard Linux encoding:
+//! - Bits 0-7:   Sequence Number (NR)
+//! - Bits 8-15:  Type/Magic (TYPE)
+//! - Bits 16-29: Size (SIZE) - 14 bits
+//! - Bits 30-31: Direction (DIR)
+
+/// Direction of the ioctl data transfer.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IoctlDir {
+    None = 0,
+    Read = 1,      // _IOC_READ
+    Write = 2,     // _IOC_WRITE
+    ReadWrite = 3, // _IOC_READ | _IOC_WRITE
+}
+
+impl IoctlDir {
+    pub const fn from_u8(val: u8) -> Self {
+        match val & 0b11 {
+            0 => IoctlDir::None,
+            1 => IoctlDir::Read,
+            2 => IoctlDir::Write,
+            3 => IoctlDir::ReadWrite,
+            _ => unsafe { core::hint::unreachable_unchecked() },
+        }
+    }
+}
+
+/// Represents a decoded ioctl command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IoctlCommand {
+    pub dir: IoctlDir,
+    pub size: u16,
+    pub magic: u8,
+    pub nr: u8,
+}
+
+impl IoctlCommand {
+    // Constants for shifting and masking (Linux Generic/RISC-V)
+    pub const NRBITS: usize = 8;
+    pub const TYPEBITS: usize = 8;
+    pub const SIZEBITS: usize = 14;
+    pub const DIRBITS: usize = 2;
+
+    pub const NRSHIFT: usize = 0;
+    pub const TYPESHIFT: usize = Self::NRSHIFT + Self::NRBITS;
+    pub const SIZESHIFT: usize = Self::TYPESHIFT + Self::TYPEBITS;
+    pub const DIRSHIFT: usize = Self::SIZESHIFT + Self::SIZEBITS;
+
+    pub const IOC_NONE: usize = 0;
+    pub const IOC_WRITE: usize = 1;
+    pub const IOC_READ: usize = 2;
+    // Note: Linux defines _IOC_READ as 2 and _IOC_WRITE as 1 in widely used generic headers,
+    // but the IoctlDir values passed into the struct use abstract 1=Read, 2=Write for simplicity.
+    // The to_raw method maps them to the correct ABI bits.
+
+    /// Create a new command.
+    ///
+    /// # Panics
+    /// Panics if size exceeds 16383 bytes (14 bits).
+    pub const fn new(dir: IoctlDir, magic: u8, nr: u8, size: usize) -> Self {
+        if size > ((1 << Self::SIZEBITS) - 1) {
+            panic!("ioctl size too large");
+        }
+        Self {
+            dir,
+            magic,
+            nr,
+            size: size as u16,
+        }
+    }
+
+    /// Decode a raw `usize` command into components.
+    pub const fn from_raw(raw: usize) -> Self {
+        let nr = (raw >> Self::NRSHIFT) as u8; // auto-masks to 8 bits because u8
+        let magic = (raw >> Self::TYPESHIFT) as u8;
+        let size = ((raw >> Self::SIZESHIFT) & ((1 << Self::SIZEBITS) - 1)) as u16;
+        let dir_val = (raw >> Self::DIRSHIFT) & ((1 << Self::DIRBITS) - 1);
+
+        // Map ABI bits to Enum
+        // Generic ABI: 00=None, 01=Write, 10=Read, 11=ReadWrite
+        /*
+        Source: RISC-V: Read=2, Write=1.
+        */
+
+        let dir = match dir_val {
+            0 => IoctlDir::None,
+            1 => IoctlDir::Write,
+            2 => IoctlDir::Read,
+            3 => IoctlDir::ReadWrite,
+            _ => IoctlDir::None, // Should be unreachable with mask
+        };
+
+        Self {
+            dir,
+            magic,
+            nr,
+            size,
+        }
+    }
+
+    /// Encode into a raw usize.
+    pub const fn to_raw(&self) -> usize {
+        let dir_bits = match self.dir {
+            IoctlDir::None => 0,
+            IoctlDir::Write => 1,
+            IoctlDir::Read => 2,
+            IoctlDir::ReadWrite => 3,
+        };
+
+        (self.nr as usize) << Self::NRSHIFT
+            | (self.magic as usize) << Self::TYPESHIFT
+            | (self.size as usize) << Self::SIZESHIFT
+            | dir_bits << Self::DIRSHIFT
+    }
+}
+
+/// Macro for defining IO command (no data).
+#[macro_export]
+macro_rules! io {
+    ($magic:expr, $nr:expr) => {
+        $crate::ioctl::IoctlCommand::new($crate::ioctl::IoctlDir::None, $magic, $nr, 0).to_raw()
+    };
+}
+
+/// Macro for defining IOR command (read from driver).
+#[macro_export]
+macro_rules! ior {
+    ($magic:expr, $nr:expr, $ty:ty) => {
+        $crate::ioctl::IoctlCommand::new(
+            $crate::ioctl::IoctlDir::Read,
+            $magic,
+            $nr,
+            core::mem::size_of::<$ty>(),
+        )
+        .to_raw()
+    };
+}
+
+/// Macro for defining IOW command (write to driver).
+#[macro_export]
+macro_rules! iow {
+    ($magic:expr, $nr:expr, $ty:ty) => {
+        $crate::ioctl::IoctlCommand::new(
+            $crate::ioctl::IoctlDir::Write,
+            $magic,
+            $nr,
+            core::mem::size_of::<$ty>(),
+        )
+        .to_raw()
+    };
+}
+
+/// Macro for defining IOWR command (read/write).
+#[macro_export]
+macro_rules! iowr {
+    ($magic:expr, $nr:expr, $ty:ty) => {
+        $crate::ioctl::IoctlCommand::new(
+            $crate::ioctl::IoctlDir::ReadWrite,
+            $magic,
+            $nr,
+            core::mem::size_of::<$ty>(),
+        )
+        .to_raw()
+    };
+}

--- a/crates/zeroos-foundation/src/lib.rs
+++ b/crates/zeroos-foundation/src/lib.rs
@@ -8,6 +8,7 @@ pub mod ioctl;
 pub mod kernel;
 pub mod kfn;
 pub mod ops;
+pub mod user_ptr;
 pub mod utils;
 
 pub use arch::SyscallFrame;

--- a/crates/zeroos-foundation/src/lib.rs
+++ b/crates/zeroos-foundation/src/lib.rs
@@ -4,6 +4,7 @@ extern crate alloc;
 
 pub mod arch;
 pub mod entry;
+pub mod ioctl;
 pub mod kernel;
 pub mod kfn;
 pub mod ops;

--- a/crates/zeroos-foundation/src/user_ptr.rs
+++ b/crates/zeroos-foundation/src/user_ptr.rs
@@ -1,0 +1,73 @@
+//! Wrapper for userspace pointers.
+
+use core::marker::PhantomData;
+use core::mem;
+
+/// Wraps a raw address to prevent accidental dereference and enforce explicit copying.
+/// We mimic Linux's __user annotation style.
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UserPtr<T> {
+    addr: usize,
+    _marker: PhantomData<T>,
+}
+
+impl<T> UserPtr<T> {
+    /// Create a new UserPtr from a raw address.
+    #[inline]
+    pub const fn new(addr: usize) -> Self {
+        Self {
+            addr,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns the raw address.
+    #[inline]
+    pub const fn as_ptr(&self) -> *mut T {
+        self.addr as *mut T
+    }
+
+    /// Check if the pointer is null.
+    #[inline]
+    pub const fn is_null(&self) -> bool {
+        self.addr == 0
+    }
+
+    /// Check if the pointer is null or misaligned for type T.
+    #[inline]
+    pub fn check(&self) -> Result<(), isize> {
+        if self.addr == 0 {
+            return Err(-(libc::EFAULT as isize));
+        }
+        if self.addr % mem::align_of::<T>() != 0 {
+            return Err(-(libc::EINVAL as isize));
+        }
+        Ok(())
+    }
+
+    /// Read a value from userspace.
+    /*
+        [NOTE] this is still unsafe because addr could be anything.
+        However, this wrapper consolidates the "unsafe" access into one place
+        where we can maintain future safeguards (like access_ok).
+    */
+
+    pub fn read(&self) -> Result<T, isize> {
+        self.check()?;
+        // TODO: Add access_ok() check here when available.
+        unsafe { Ok(core::ptr::read_volatile(self.as_ptr() as *const T)) }
+    }
+
+    /// Write a value to userspace.
+    pub fn write(&self, val: T) -> Result<(), isize> {
+        self.check()?;
+        // TODO: Add access_ok() check here when available.
+        unsafe {
+            core::ptr::write_volatile(self.as_ptr(), val);
+        }
+        Ok(())
+    }
+}
+
+pub type UserVoidPtr = UserPtr<u8>;

--- a/doc/ioctl_cmd.md
+++ b/doc/ioctl_cmd.md
@@ -1,0 +1,37 @@
+# ioctl Command Encoding in ZeroOS
+
+ZeroOS adopts the standard Linux-style bit-packing for `ioctl` commands to ensure compatibility and robustness. This encoding embeds the command's direction, size, magic number (type), and sequence number into a single 32-bit integer.
+
+## Bit Layout
+
+The 32-bit command (`u32` / `usize`) is structured as follows:
+
+| Bits      | Label  | Width | Description                                                            |
+| :-------- | :----- | :---- | :--------------------------------------------------------------------- |
+| **0-7**   | `NR`   | 8     | **Number**: Implementing sequence number (0-255).                      |
+| **8-15**  | `TYPE` | 8     | **Type (Magic)**: Unique ASCII character for the driver (e.g., `'k'`). |
+| **16-29** | `SIZE` | 14    | **Size**: Size of the data argument in bytes (max 16KB).               |
+| **30-31** | `DIR`  | 2     | **Direction**: Data transfer direction (None, Read, Write, ReadWrite). |
+
+## Directions (`DIR`)
+
+| Value | Macro   | Direction | Description                                                  |
+| :---- | :------ | :-------- | :----------------------------------------------------------- |
+| `00`  | `_IO`   | None      | No data transfer. Argument is ignored or treated as a value. |
+| `10`  | `_IOW`  | Write     | Userspace writes data to the kernel/device.                  |
+| `01`  | `_IOR`  | Read      | Userspace reads data from the kernel/device.                 |
+| `11`  | `_IOWR` | ReadWrite | Bidirectional transfer (Read-Modify-Write).                  |
+
+> **Note**: This differs slightly from some architectures where Read/Write bits might be swapped, but follows the generic Linux convention used on RISC-V.
+
+## Usage in Rust
+
+ZeroOS provides the `IoctlCommand` struct to parse and encode these values type-safely.
+
+```rust
+use zeroos_foundation::ioctl::{IoctlCommand, IoctlDir};
+
+let cmd = IoctlCommand::new(IoctlDir::Read, b'X', 1, 4); // Creating a command to READ a 4-byte integer from driver 'X', sequence 1
+
+let raw = cmd.to_raw(); 
+```


### PR DESCRIPTION
As a part of adding device support to ZeroOS, this is phase 1 of the overhaul of ioctl (sys_ioctl).

This PR includes:

- Command encoding for ioctl
- - We copied the Linux style bit packing for ioctl. As such, the encoding embeds the command's direction, size, magic number (type), and sequence number into a single 32-bit integer.
- - The structure (bit layout and directions) are defined in doc/ioctl_cmd.md
- A type-safe wrapper for an abstracted user pointer
- - I will write the docs for it soon. It's pretty simple duh.

Currently, read and write use `core::ptr::read/write_volatile`. In the future, this will be integrated with the architecture's page-fault handling mechanism (e.g., `access_ok` checks) to gracefully handle invalid addresses without panicking the kernel. Just so I know.